### PR TITLE
Remove internet permission

### DIFF
--- a/iap/build.gradle
+++ b/iap/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    implementation "com.android.billingclient:billing-ktx:3.0.2"
+    implementation "com.android.billingclient:billing-ktx:3.0.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
 }

--- a/iap/src/main/AndroidManifest.xml
+++ b/iap/src/main/AndroidManifest.xml
@@ -1,6 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.alphelios.iap">
-
-    <uses-permission android:name="android.permission.INTERNET"/>
-
+<manifest package="com.alphelios.iap">
 </manifest>


### PR DESCRIPTION
There is no need for this permission.  
`com.android.vending.BILLING` inherited from the billing library will suffice.  
```
The Google Play Billing Library embeds the com.android.vending.BILLING permission inside its manifest. It is no longer necessary to explicitly add this permission inside your app's manifest.
```