### PR TITLE
onPricesUpdated returns full SKU details

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ dependencies {
 
 ```kotlin
  iapConnector.addPurchaseListener(object : PurchaseServiceListener {
-            override fun onPricesUpdated(iapKeyPrices: Map<String, String>) {
+            override fun onPricesUpdated(iapKeyPrices: Map<String, DataWrappers.SkuDetails>) {
                 // list of available products will be received here, so you can update UI with prices if needed
             }
 
@@ -110,7 +110,7 @@ dependencies {
                 // will be triggered whenever subscription succeeded
             }
 
-            override fun onPricesUpdated(iapKeyPrices: Map<String, String>) {
+            override fun onPricesUpdated(iapKeyPrices: Map<String, DataWrappers.SkuDetails>) {
                 // list of available products will be received here, so you can update UI with prices if needed
             }
         })

--- a/app/src/main/java/com/limerse/iapsample/JavaSampleActivity.java
+++ b/app/src/main/java/com/limerse/iapsample/JavaSampleActivity.java
@@ -46,17 +46,13 @@ class JavaSampleActivity extends AppCompatActivity {
             public void onProductPurchased(DataWrappers.PurchaseInfo purchaseInfo) {
                 if (purchaseInfo.getSku().equals("plenty")) {
 
-                }
-                else if (purchaseInfo.getSku().equals("yearly")) {
+                } else if (purchaseInfo.getSku().equals("yearly")) {
 
-                }
-                else if (purchaseInfo.getSku().equals("moderate")) {
+                } else if (purchaseInfo.getSku().equals("moderate")) {
 
-                }
-                else if (purchaseInfo.getSku().equals("base")) {
+                } else if (purchaseInfo.getSku().equals("base")) {
 
-                }
-                else if (purchaseInfo.getSku().equals("quite")) {
+                } else if (purchaseInfo.getSku().equals("quite")) {
 
                 }
             }

--- a/app/src/main/java/com/limerse/iapsample/KotlinSampleActivity.kt
+++ b/app/src/main/java/com/limerse/iapsample/KotlinSampleActivity.kt
@@ -33,7 +33,7 @@ class KotlinSampleActivity : AppCompatActivity() {
         )
 
         iapConnector.addPurchaseListener(object : PurchaseServiceListener {
-            override fun onPricesUpdated(iapKeyPrices: Map<String, String>) {
+            override fun onPricesUpdated(iapKeyPrices: Map<String, DataWrappers.SkuDetails>) {
                 // list of available products will be received here, so you can update UI with prices if needed
             }
 
@@ -69,14 +69,14 @@ class KotlinSampleActivity : AppCompatActivity() {
 
             override fun onSubscriptionPurchased(purchaseInfo: DataWrappers.PurchaseInfo) {
                 // will be triggered whenever subscription succeeded
-                when(purchaseInfo.sku){
-                    "subscription"->{
+                when (purchaseInfo.sku) {
+                    "subscription" -> {
 
                     }
                 }
             }
 
-            override fun onPricesUpdated(iapKeyPrices: Map<String, String>) {
+            override fun onPricesUpdated(iapKeyPrices: Map<String, DataWrappers.SkuDetails>) {
                 // list of available products will be received here, so you can update UI with prices if needed
             }
         })

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 15 14:03:14 IST 2021
+#Fri Oct 01 13:20:39 IST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/iap/src/main/java/com/limerse/iap/BillingServiceListener.kt
+++ b/iap/src/main/java/com/limerse/iap/BillingServiceListener.kt
@@ -6,5 +6,5 @@ interface BillingServiceListener {
      *
      * @param iapKeyPrices - a map with available products
      */
-    fun onPricesUpdated(iapKeyPrices: Map<String, String>)
+    fun onPricesUpdated(iapKeyPrices: Map<String, DataWrappers.SkuDetails>)
 }

--- a/iap/src/main/java/com/limerse/iap/DataWrappers.kt
+++ b/iap/src/main/java/com/limerse/iap/DataWrappers.kt
@@ -25,6 +25,23 @@ class DataWrappers {
         var isConsumable: Boolean = false
     )
 
+
+    data class SkuDetails(
+        val title: String?,
+        val description: String?,
+        val priceCurrencyCode: String?,
+        val freeTrailPeriod: String?,
+        val introductoryPrice: String?,
+        val introductoryPriceAmount: Double?,
+        val introductoryPriceCycles: Int?,
+        val introductoryPricePeriod: String?,
+        val originalPrice: String?,
+        val originalPriceAmount: Double?,
+        val price: String?,
+        val priceAmount: Double?,
+        val subscriptionPeriod: String?,
+    )
+
     data class PurchaseInfo(
         val skuInfo: SkuInfo,
         val purchaseState: Int,

--- a/iap/src/main/java/com/limerse/iap/IBillingService.kt
+++ b/iap/src/main/java/com/limerse/iap/IBillingService.kt
@@ -8,7 +8,8 @@ import androidx.annotation.CallSuper
 abstract class IBillingService {
 
     private val purchaseServiceListeners: MutableList<PurchaseServiceListener> = mutableListOf()
-    private val subscriptionServiceListeners: MutableList<SubscriptionServiceListener> = mutableListOf()
+    private val subscriptionServiceListeners: MutableList<SubscriptionServiceListener> =
+        mutableListOf()
 
     fun addPurchaseListener(purchaseServiceListener: PurchaseServiceListener) {
         purchaseServiceListeners.add(purchaseServiceListener)
@@ -66,13 +67,13 @@ abstract class IBillingService {
         }
     }
 
-    fun updatePrices(iapkeyPrices: Map<String, String>) {
+    fun updatePrices(iapkeyPrices: Map<String, DataWrappers.SkuDetails>) {
         findUiHandler().post {
             updatePricesInternal(iapkeyPrices)
         }
     }
 
-    fun updatePricesInternal(iapkeyPrices: Map<String, String>) {
+    fun updatePricesInternal(iapkeyPrices: Map<String, DataWrappers.SkuDetails>) {
         for (billingServiceListener in purchaseServiceListeners) {
             billingServiceListener.onPricesUpdated(iapkeyPrices)
         }

--- a/iap/src/main/java/com/limerse/iap/IapConnector.kt
+++ b/iap/src/main/java/com/limerse/iap/IapConnector.kt
@@ -25,7 +25,8 @@ class IapConnector @JvmOverloads constructor
 
     init {
         val contextLocal = context.applicationContext ?: context
-        mBillingService = BillingService(contextLocal, nonConsumableKeys, consumableKeys, subscriptionKeys)
+        mBillingService =
+            BillingService(contextLocal, nonConsumableKeys, consumableKeys, subscriptionKeys)
         getBillingService().init(key)
         getBillingService().enableDebugLogging(enableLogging)
     }

--- a/iap/src/main/java/com/limerse/iap/PurchaseServiceListener.kt
+++ b/iap/src/main/java/com/limerse/iap/PurchaseServiceListener.kt
@@ -6,7 +6,7 @@ interface PurchaseServiceListener : BillingServiceListener {
      *
      * @param iapKeyPrices - a map with available products
      */
-    override fun onPricesUpdated(iapKeyPrices: Map<String, String>)
+    override fun onPricesUpdated(iapKeyPrices: Map<String, DataWrappers.SkuDetails>)
 
     /**
      * Callback will be triggered when a product purchased successfully


### PR DESCRIPTION
#56

`onPricesUpdated` send `iapKeyPrices: Map<String, String> `which contains the list of SKUs and their price.

Currently, the price is a String Eg: Rs. 300.00
Now, it returns `Map<String, DataWrappers.SkuDetails>`. So, users can get "Rs." and "300.00" separately. This helps in building the UI dynamically after fetching the SKU information.

