### PR TITLE
Remove unnecessary app_name attribute

### DIFF
--- a/iap/src/main/res/values/strings.xml
+++ b/iap/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name">IAP</string>
 </resources>


### PR DESCRIPTION
This attribute is normally used by apps, not libraries, to specify the launcher name. Most apps have this exact same attribute in their manifest file (it's the Android Studio default), and so even if they accidentally remove their own app_name attribute, the one in this library will take over and they'll see no errors, except that the launcher icon of their app is now saying "IAP". This happened to me and I was confused as hell :p

I'm not sure if this is being used in any other parts of code, so make sure this change doesn't break anything.