### PR TITLE
Adding onPurchaseFailed callback, Fixing onProductPurchased not called immediately.

### DIFF
--- a/app/src/main/java/com/limurse/iapsample/JavaSampleActivity.java
+++ b/app/src/main/java/com/limurse/iapsample/JavaSampleActivity.java
@@ -2,6 +2,7 @@ package com.limurse.iapsample;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -71,6 +72,11 @@ class JavaSampleActivity extends AppCompatActivity {
             public void onProductRestored(@NonNull DataWrappers.PurchaseInfo purchaseInfo) {
 
             }
+
+            @Override
+            public void onPurchaseFailed(@Nullable DataWrappers.PurchaseInfo purchaseInfo, @Nullable Integer billingResponseCode) {
+                Toast.makeText(getApplicationContext(), "Your purchase has been failed", Toast.LENGTH_SHORT).show();
+            }
         });
         iapConnector.addSubscriptionListener(new SubscriptionServiceListener() {
             public void onSubscriptionRestored(@NonNull DataWrappers.PurchaseInfo purchaseInfo) {
@@ -84,6 +90,10 @@ class JavaSampleActivity extends AppCompatActivity {
 
             public void onPricesUpdated(@NotNull Map iapKeyPrices) {
 
+            }
+
+            @Override
+            public void onPurchaseFailed(@Nullable DataWrappers.PurchaseInfo purchaseInfo, @Nullable Integer billingResponseCode) {
             }
         });
 

--- a/app/src/main/java/com/limurse/iapsample/KotlinSampleActivity.kt
+++ b/app/src/main/java/com/limurse/iapsample/KotlinSampleActivity.kt
@@ -2,6 +2,7 @@ package com.limurse.iapsample
 
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.MutableLiveData
 import com.limurse.iap.BillingClientConnectionListener
@@ -77,6 +78,11 @@ class KotlinSampleActivity : AppCompatActivity() {
             override fun onProductRestored(purchaseInfo: DataWrappers.PurchaseInfo) {
                 // will be triggered fetching owned products using IapConnector;
             }
+
+            override fun onPurchaseFailed(purchaseInfo: DataWrappers.PurchaseInfo?, billingResponseCode: Int?) {
+                // will be triggered whenever a product purchase is failed
+                Toast.makeText(applicationContext, "Your purchase has been failed", Toast.LENGTH_SHORT).show()
+            }
         })
 
         iapConnector.addSubscriptionListener(object : SubscriptionServiceListener {
@@ -98,6 +104,10 @@ class KotlinSampleActivity : AppCompatActivity() {
 
             override fun onPricesUpdated(iapKeyPrices: Map<String, List<DataWrappers.ProductDetails>>) {
                 // list of available products will be received here, so you can update UI with prices if needed
+            }
+
+            override fun onPurchaseFailed(purchaseInfo: DataWrappers.PurchaseInfo?, billingResponseCode: Int?) {
+                // will be triggered whenever subscription purchase is failed
             }
         })
 

--- a/iap/src/main/java/com/limurse/iap/BillingService.kt
+++ b/iap/src/main/java/com/limurse/iap/BillingService.kt
@@ -193,11 +193,12 @@ class BillingService(
 
                     // Grant entitlement to the user.
                     val productDetails = productDetails[purchase.products[0]]
+                    val isProductConsumable = consumableKeys.contains(purchase.products[0])
                     when (productDetails?.productType) {
                         BillingClient.ProductType.INAPP -> {
                             // Consume the purchase
                             when {
-                                consumableKeys.contains(purchase.products[0]) -> {
+                                isProductConsumable && purchase.purchaseState == Purchase.PurchaseState.PURCHASED -> {
                                     mBillingClient.consumeAsync(
                                         ConsumeParams.newBuilder()
                                             .setPurchaseToken(purchase.purchaseToken).build()
@@ -227,7 +228,7 @@ class BillingService(
                     }
 
                     // If the state is PURCHASED, acknowledge the purchase if it hasn't been acknowledged yet.
-                    if (!purchase.isAcknowledged && purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
+                    if (!purchase.isAcknowledged && !isProductConsumable && purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
                         val acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
                             .setPurchaseToken(purchase.purchaseToken).build()
                         mBillingClient.acknowledgePurchase(acknowledgePurchaseParams, this)

--- a/iap/src/main/java/com/limurse/iap/BillingServiceListener.kt
+++ b/iap/src/main/java/com/limurse/iap/BillingServiceListener.kt
@@ -7,4 +7,12 @@ interface BillingServiceListener {
      * @param iapKeyPrices - a map with available products
      */
     fun onPricesUpdated(iapKeyPrices: Map<String, List<DataWrappers.ProductDetails>>)
+
+    /**
+     * Callback will be triggered when a purchase was failed.
+     *
+     * @param purchaseInfo - specifier of purchase info if exists
+     * @param billingResponseCode - response code returned from the billing library if exists
+     */
+    fun onPurchaseFailed(purchaseInfo: DataWrappers.PurchaseInfo?, billingResponseCode: Int?)
 }

--- a/iap/src/main/java/com/limurse/iap/IBillingService.kt
+++ b/iap/src/main/java/com/limurse/iap/IBillingService.kt
@@ -98,6 +98,27 @@ abstract class IBillingService {
         }
     }
 
+    fun updateFailedPurchases(purchaseInfo: List<DataWrappers.PurchaseInfo>? = null, billingResponseCode: Int? = null) {
+        purchaseInfo?.forEach {
+            updateFailedPurchase(it, billingResponseCode)
+        } ?: updateFailedPurchase()
+    }
+
+    fun updateFailedPurchase(purchaseInfo: DataWrappers.PurchaseInfo? = null, billingResponseCode: Int? = null) {
+        findUiHandler().post {
+            updateFailedPurchasesInternal(purchaseInfo, billingResponseCode)
+        }
+    }
+
+    private fun updateFailedPurchasesInternal(purchaseInfo: DataWrappers.PurchaseInfo? = null, billingResponseCode: Int? = null) {
+        for (billingServiceListener in purchaseServiceListeners) {
+            billingServiceListener.onPurchaseFailed(purchaseInfo, billingResponseCode)
+        }
+        for (billingServiceListener in subscriptionServiceListeners) {
+            billingServiceListener.onPurchaseFailed(purchaseInfo, billingResponseCode)
+        }
+    }
+
     abstract fun init(key: String?)
     abstract fun buy(activity: Activity, sku: String, obfuscatedAccountId: String?, obfuscatedProfileId: String?)
     abstract fun subscribe(activity: Activity, sku: String, obfuscatedAccountId: String?, obfuscatedProfileId: String?)


### PR DESCRIPTION
I have added onPurchaseFailed callback, which will be triggered when the purchase is failed, as currently there is no way to know if the user did exit the payment flow or not, for showing a progress bar indicates that the payment is still in progress for example.
Additionally, I have fixed this issue https://github.com/akshaaatt/Google-IAP/issues/45 , which was making the library unusable.